### PR TITLE
libmouse_poller.so, not mouse_poller.so

### DIFF
--- a/mouse-poller/config.ini
+++ b/mouse-poller/config.ini
@@ -6,7 +6,7 @@ reloadable=true
 lib="mouse_poller.dll"
 
 [X11.64]
-lib="mouse_poller.so"
+lib="libmouse_poller.so"
 
 [MousePoller]
 extends="Reference"


### PR DESCRIPTION
Encountered this bug when packaging this. A new release should be made.